### PR TITLE
fix: open attribute reference in write mode when writing to it

### DIFF
--- a/Gile.AutoCAD.R20.Extension/BlockReferenceExtension.cs
+++ b/Gile.AutoCAD.R20.Extension/BlockReferenceExtension.cs
@@ -83,7 +83,7 @@ namespace Gile.AutoCAD.R20.Extension
             Assert.IsNotNullOrWhiteSpace(tag, nameof(tag));
             Assert.IsNotNull(value, nameof(value));
 
-            foreach (AttributeReference attRef in target.AttributeCollection.GetObjects(tr))
+            foreach (AttributeReference attRef in target.AttributeCollection.GetObjects(tr, OpenMode.ForWrite))
             {
                 if (attRef.Tag == tag)
                 {


### PR DESCRIPTION
Changing an object opened in read only mode causes fatal error.